### PR TITLE
docker: better usage of build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu:trusty
-ADD . /code
-WORKDIR /code
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y git software-properties-common python python-dev python-pip && \
     add-apt-repository -y ppa:chris-lea/node.js && \
     apt-get install -y nodejs
     npm install bower
+WORKDIR /code
+ADD requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
+ADD . /code


### PR DESCRIPTION
* Reorders Dockerfile instructions to put "ADD code base" statement very
  late in the build process chain, so that one can profit from the build
  cache (for both OS base packages and for Python dependencies) when
  rebuilding the image after the code base changes.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>