### PR TITLE
docker: bower and user improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,30 @@
+# Ubuntu 14.04 LTS (Trusty Tahr)
 FROM ubuntu:trusty
+
+# Install OS prerequisites:
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y git software-properties-common python python-dev python-pip && \
     add-apt-repository -y ppa:chris-lea/node.js && \
-    apt-get install -y nodejs
-    npm install bower
+    apt-get install -y nodejs nodejs-legacy npm && \
+    apt-get clean && \
+    npm install -g bower
+
+# Install Pythonic prerequisites:
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+# Run container as `www-data` user, with forced UID of 1000, which
+# should match current host user in most situations:
+RUN usermod -o -u 1000 www-data && groupmod -o -g 1000 www-data
+USER www-data
+
+# Finally, add sources to `/code` directory:
 WORKDIR /code
-ADD requirements.txt /code/requirements.txt
-RUN pip install -r requirements.txt
 ADD . /code
+
+# ... and run Bower like this:
+#RUN CI=true bower install
+
+# Start the application:
+CMD ["python", "app.py"]


### PR DESCRIPTION
* Amends installation instructions to install all bower prerequisites.
  Shows example how to run bower, should generated components not be
  committed in the sources.

* Sets container user to `www-data` and forces its UID to be 1000, which
  should match host user identity in most scenarios.

* Launches explicit `apt-get clean` to reduce the size of the container.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>